### PR TITLE
various md fixes for finance meeting notes

### DIFF
--- a/meetings/2022/20220411-finance.md
+++ b/meetings/2022/20220411-finance.md
@@ -1,6 +1,6 @@
 # 2022.04.11
-
 - April 11, 2022. 1600 Pacific Time
+
 - [Agenda](https://github.com/SeaGL/organization/issues/249)
 - [Shared Pad](https://pad.seattlematrix.org/p/SeaGL_2022_finance)
 - [Jitsi URL](https://meet.seattlematrix.org/SeaGL_2022_finance)
@@ -16,7 +16,6 @@
 - Note Taker(s): Norm
 - Note Taker(s) for next time: 
 
-
 - [2021 fiscal sponsor details](https://docs.google.com/spreadsheets/d/1On-iXCVhR1jgV4hCXdmTkLunlayPYrMA9nCmRBwuz10/)
 - [budget](https://docs.google.com/spreadsheets/d/1ahnCfPKe7BAO3y8X4n69BJyfL8NNQRooW5fOXhH-VBQ/)
 - [2021 lead sheet](https://docs.google.com/spreadsheets/d/1AZx2F2zmOQD-lfBdHj9YWNqvndj8lShrXjrbS43-8Es/)
@@ -27,7 +26,8 @@
 ### How to document/verify that we have been paid?
 - This taken care of by the shared spreadsheet?
 - Would like to hve a verification email or something.
-- can we get a monthly (or more regular) accounting? can this be in a csv so that we can have in rev control?
+- can we get a monthly (or more regular) accounting?
+  - can this be in a csv so that we can have in rev control?
 - want to wait on spreadsheet magic until we know where we are heading
 
 ### sponsor prospectus timeline / shared labor
@@ -37,7 +37,8 @@
 
 ### higher priority spreadsheet or prospectus?
 - prospectus would seem a higher priority, but...
-  - We do not know what we are doing this year.   hybrid or virtual
+  - We do not know what we are doing this year.
+    - hybrid or virtual
   - prospectus delayed until venue type is decided next month.
 - Spreadsheet higher priority right now.
   - fields to document OSI 'API'.
@@ -56,47 +57,54 @@
 - Monthly meetins with OSI financial?
   - Maybe get the monthly data a week before? Not waiting for the day of to review.
   - New, outstanding, recent items.
-  
-  # Misc Items
-  - Periodic coffee/doughnuts for the teams?
+
+#### Misc Items
+- Periodic coffee/doughnuts for the teams?
 
 ### Retrospective
-  - https://github.com/SeaGL/organization/blob/main/meetings/2021/20211115-retrospective.md
-  - work through budget requests, including old ones stuck around from 2020 (Hans)
-  - add links referencing documents that committee generated (or relied on) for 2021 (Everyone)
-    - https://etherpad.seattlematrix.org/p/SeaGL_2021_links
-  - submit 2021 reimbursement requests before Dec 1 by opening a GH issue and tagging der.hans (Everyone)
-  - confirm Mind's Eye has gotten paid from OSI (Salt)
-    - Meet with OSI
-    - Can we make it right by giving a 'bonus'?
-  - Bikeshed
-    - continue to streamline sponsor processing
-    - fully transition to consistent document formats
-    - write more documentation for external consumption
+- https://github.com/SeaGL/organization/blob/main/meetings/2021/20211115-retrospective.md
+- work through budget requests, including old ones stuck around from 2020 (Hans)
+- add links referencing documents that committee generated (or relied on) for 2021 (Everyone)
+  - https://etherpad.seattlematrix.org/p/SeaGL_2021_links
+- submit 2021 reimbursement requests before Dec 1 by opening a GH issue and tagging der.hans (Everyone)
+- confirm Mind's Eye has gotten paid from OSI (Salt)
+  - Meet with OSI
+  - Can we make it right by giving a 'bonus'?
 
-  ### Timeline
-  - Decision on hybrid/virtual first meeting after May 1.
-    - Prospectus middle of May
-  - LOE on spreadsheet April 18th.
-    - date/signature on items not a priority.
-  - Monthly transactions - April 25th.
-  - Outstanding financial items
-    - Ben's April 18th.
-    - Find all items already turned in...  get summary. April 25th
-      - See what is not in process yet.
+#### Bikeshed
+- continue to streamline sponsor processing
+- fully transition to consistent document formats
+- write more documentation for external consumption
+
+### Timeline
+- Decision on hybrid/virtual first meeting after May 1.
+  - Prospectus middle of May
+- LOE on spreadsheet April 18th.
+  - date/signature on items not a priority.
+- Monthly transactions
+  - April 25th.
+- Outstanding financial items
+  - Ben's April 18th.
+  - Find all items already turned in...
+    - get summary. April 25th
+    - See what is not in process yet.
 
 ### Partnerships
 - No one so far.
   - Need to discuss on next meeting.
-- Hans to put writeup for Partnerships committee - April 14th to give to Salt.
+- Hans to put writeup for Partnerships committee
+  - April 14th to give to Salt.
 
 ### IDEA - mentioned in meeting.
 - Hans requesting writeup of what we are looking for in people (Salt).
 
 ###  Meeting time good?
 - Time is good
-- Every other week good for now.   Can always meet the day before the all-hands.
-- Opposite week of all-hands good.   week to prep for the all-hands.  also get time to work on todo from all-hands.
+- Every other week good for now.
+  - Can always meet the day before the all-hands.
+- Opposite week of all-hands good.
+  - week to prep for the all-hands.
+  - also get time to work on todo from all-hands.
 
 ### Sign-off round (what's next, appreciations, suggestions)
 - Norm:  Glad for first meeting.  Good to see everyone.

--- a/meetings/2022/20220425-finance.md
+++ b/meetings/2022/20220425-finance.md
@@ -1,12 +1,10 @@
-
 # 2022.04.25 SeaGl Finance
-
 - April 25, 2022. 1600 Pacific Time
+
 - [Shared Pad](https://pad.seattlematrix.org/p/SeaGL_2022_finance)
 - [Jitsi URL](https://meet.seattlematrix.org/SeaGL_2022_finance)
 - [Previous meeting minutes](https://github.com/SeaGL/organization/tree/main/meetings/2022)
 - [Mailing list](https://groups.google.com/a/seagl.org/g/seagl2022)
-
 
 ## Procedural
 ### Check-in round
@@ -22,7 +20,8 @@
 
 ## Previous ToDo
 ### Angenda for next week
-- Sponsors - Different tier for smaller companies/individual?
+- Sponsors
+  - Different tier for smaller companies/individual?
 - No one in partnerships
 
 ### References
@@ -36,39 +35,44 @@
 ### How to document/verify that we have been paid?
 - This taken care of by the shared spreadsheet?
 - Would like to hve a verification email or something.
-- can we get a monthly (or more regular) accounting? can this be in a csv so that we can have in rev control?
+- can we get a monthly (or more regular) accounting?
+  - can this be in a csv so that we can have in rev control?
 - want to wait on spreadsheet magic until we know where we are heading
 - CC finance on all emails with OSI.
-  [ ] Email OSI and start discussion on the above  (Norm)
+  - [ ] Email OSI and start discussion on the above  (Norm)
 
 ### sponsor prospectus timeline / shared labor
-  [ ] request monthly transactions (hans/norm)
+- [ ] request monthly transactions (hans/norm)
+
 ### investigate formular to capture person and datestamp when an account is marked paid (hans)
 - Hans worked on formulas, but did not get that far.
   - 3-5 hours to convert it.
   - how do we want to deal with sponsors
-    - paid vs non-paid.   OSI not involved with non-paid, but contracts, etc?
+    - paid vs non-paid.
+      - OSI not involved with non-paid, but contracts, etc?
     - keep lead sheet seperate from the actual sponsor spreadsheet.
       - reduce info/discussion with OSI
       - protect info of lead sheet.
-  - people/timestamps is difficult.   may just use dropdowns/hand enter
+  - people/timestamps is difficult.
+    -  may just use dropdowns/hand enter
   - Hans looking at NextCloud.
-  [x] determine loe to move to OSI budget spreadsheet (hans)
-  [ ] Finish prepping the OSI spreadsheet (hans and norm working session)
-  [ ]  Move Lead Sheet over to NextCloud  (hans and norm working session)
+- [x] determine loe to move to OSI budget spreadsheet (hans)
+- [ ] Finish prepping the OSI spreadsheet (hans and norm working session)
+- [ ] Move Lead Sheet over to NextCloud  (hans and norm working session)
 
 ###  Sponsors
-- Different tier for smaller companies/individual?   
+- Different tier for smaller companies/individual?
 
 ### higher priority spreadsheet or prospectus?
 - prospectus would seem a higher priority, but...
-  - We do not know what we are doing this year.   hybrid or virtual
+  - We do not know what we are doing this year.
+    - hybrid or virtual
   - prospectus delayed until venue type is decided next month.
 - Spreadsheet higher priority right now.
   - fields to document OSI 'API'.
   - also track who enters what on which date.
   - easy to use/transform data from monthly updates.
-  [ ] Draft Prospectus.  Next week by All-hands.   (Salt)
+  - [ ] Draft Prospectus.  Next week by All-hands. (Salt)
 - https://docs.google.com/document/d/1KLPVivebRZUxb5tAyT8hnNhCHmEnPzdS2CbdYRx-eHA/edit#
 
 ### Outstanding Financial items
@@ -83,45 +87,49 @@
 - Monthly meetins with OSI financial?
   - Maybe get the monthly data a week before? Not waiting for the day of to review.
   - New, outstanding, recent items.
-  [ ] Include in email to OSI (Norm)
-- Salt paying for storage.  Moved out and then in.
-  
+  - [ ] Include in email to OSI (Norm)
+- Salt paying for storage.
+  - Moved out and then in.
+
 ### Misc Items
-  - Periodic coffee/doughnuts for the teams?
-    - Maybe OSI when we first meeting with them.
-    - Committees...  $200 for each for team building?
-       - Feedback in the All-hands
-    - Gift Cards for remote/virtual meetings?
+- Periodic coffee/doughnuts for the teams?
+  - Maybe OSI when we first meeting with them.
+- Committees...
+  - $200 for each for team building?
+  - Feedback in the All-hands
+- Gift Cards for remote/virtual meetings?
 
 ## Retrospective
-  - https://github.com/SeaGL/organization/blob/main/meetings/2021/20211115-retrospective.md
-  - work through budget requests, including old ones stuck around from 2020 (Hans)
-  - add links referencing documents that committee generated (or relied on) for 2021 (Everyone)
-    - https://etherpad.seattlematrix.org/p/SeaGL_2021_links
-  - submit 2021 reimbursement requests before Dec 1 by opening a GH issue and tagging der.hans (Everyone)
-  - confirm Mind's Eye has gotten paid from OSI (Salt)
-    - Meet with OSI
-      - What can we legally do to give them up to 5K?
-      - What other 'gotchas' for using out of country peole?
-      - A way to change the contract/wording to not have the 30% held?
-      - Need to test spreadsheet/process
-    - Can we make it right by giving a 'bonus'?
-    - Talk to Nathan (after OSI meeting).
-  - Bikeshed
-    - continue to streamline sponsor processing
-    - fully transition to consistent document formats
-    - write more documentation for external consumption
+- https://github.com/SeaGL/organization/blob/main/meetings/2021/20211115-retrospective.md
+- work through budget requests, including old ones stuck around from 2020 (Hans)
+- add links referencing documents that committee generated (or relied on) for 2021 (Everyone)
+  - https://etherpad.seattlematrix.org/p/SeaGL_2021_links
+- submit 2021 reimbursement requests before Dec 1 by opening a GH issue and tagging der.hans (Everyone)
+- [ ] confirm Mind's Eye has gotten paid from OSI (Salt)
+  - Meet with OSI
+    - What can we legally do to give them up to 5K?
+    - What other 'gotchas' for using out of country peole?
+    - A way to change the contract/wording to not have the 30% held?
+    - Need to test spreadsheet/process
+  - Can we make it right by giving a 'bonus'?
+  - Talk to Nathan (after OSI meeting).
 
-  ## Timeline
-  - Decision on hybrid/virtual first meeting after May 1.
-    - Prospectus middle of May
-  - Monthly transactions - April 25th.
-  - Outstanding financial items
-    - Ben's April 18th.
-    - Find all items already turned in...  get summary. April 25th
-      - See what is not in process yet.
+### Bikeshed
+- continue to streamline sponsor processing
+- fully transition to consistent document formats
+- write more documentation for external consumption
 
-###  Transaction Tech
+## Timeline
+- Decision on hybrid/virtual first meeting after May 1.
+  - Prospectus middle of May
+- Monthly transactions - April 25th.
+- Outstanding financial items
+  - Ben's April 18th.
+  - Find all items already turned in...
+    - get summary. April 25th
+    - See what is not in process yet.
+
+### Transaction Tech
 - Ask tech if can have a github template for budget items, re-imbursements,
   - NEED A PRIVATE AREA/REPOSITORY
 - NextCloud has a forms tool that could export to CSV, then import 
@@ -129,27 +137,40 @@
 # Partnerships
 - No one so far.
   - Need to discuss on next meeting.
-[x]Hans to put writeup for Partnerships committee - April 14th to give to Salt.
+- [x] Hans to put writeup for Partnerships committee
+  - April 14th to give to Salt.
 
 # IDEA - mentioned in meeting.
-[ ] Hans requesting writeup of what we are looking for in people (Salt).
+- [ ] Hans requesting writeup of what we are looking for in people (Salt).
 
-#  Meeting time good?
+# Meeting time good?
 - Time is good
-- Every other week good for now.   Can always meet the day before the all-hands.
-- Opposite week of all-hands good.   week to prep for the all-hands.  also get time to work on todo from all-hands.
+- Every other week good for now.
+  - Can always meet the day before the all-hands.
+- Opposite week of all-hands good.
+  - week to prep for the all-hands.
+  - also get time to work on todo from all-hands.
 
 # New items for next week
-- RedHat program? - brought by Salt
-- https://contributor.link/
-- Once we get non-profit, working other companies - OpenSuse (since we use their calendar), etc. - brought by Hans
-- Document what we are using and how.   What is pro/con of the item. Example: Big blue button.  Hopefully promote communittee discussion. - brought by Hans
+- RedHat program?
+  - brought by Salt
+  - https://contributor.link/
+- Once we get non-profit, working other companies
+  - OpenSuse (since we use their calendar), etc.
+  - brought by Hans
+- Document what we are using and how.
+  - What is pro/con of the item.
+  - Example: Big blue button.
+  - Hopefully promote communittee discussion.
+  - brought by Hans
 
-Future partnership leads
-- Jupiter broadcasting (podcast) - help promote
+# Future partnership leads
+- Jupiter broadcasting (podcast)
+  - help promote
   - self hosted show (ssh).
 - Tuxedo computers
-- Destination linux (podcast) - help promote
+- Destination linux (podcast)
+  - help promote
 - Linux Magazine has a calendar of events.
   - https://www.linux-magazine.com/Resources/Event-Calendar#
 

--- a/meetings/2022/20220509-finance.md
+++ b/meetings/2022/20220509-finance.md
@@ -1,7 +1,6 @@
-
 # 2022.05.23 SeaGl Finance
-
 - May 23rd, 2022. 1600 Pacific Time
+
 - [Shared Pad](https://pad.seattlematrix.org/p/SeaGL_2022_finance)
 - [Jitsi URL](https://meet.seattlematrix.org/SeaGL_2022_finance)
 - [Previous meeting minutes](https://github.com/SeaGL/organization/tree/main/meetings/2022)
@@ -39,52 +38,56 @@
 - can we get a monthly (or more regular) accounting? can this be in a csv so that we can have in rev control?
 - want to wait on spreadsheet magic until we know where we are heading
 - CC finance on all emails with OSI.
-  [ ] Email OSI and start discussion on the above  (Norm)
+  - [ ] Email OSI and start discussion on the above (Norm)
 
 ### sponsor prospectus timeline / shared labor
-  [ ] request monthly transactions (hans/norm)
+- [ ] request monthly transactions (hans/norm)
+
 #### Prospectus/Sponsorship discusstion
-[ ] Draft Prospectus.  Next week by All-hands.   (Salt)
+- [ ] Draft Prospectus. Next week by All-hands. (Salt)
   - https://docs.google.com/document/d/1KLPVivebRZUxb5tAyT8hnNhCHmEnPzdS2CbdYRx-eHA/edit#
 - Add-ons?
-    - Maybe give add-on numbers per tier of sponsorship?  What virtual add-ons that were sponsored in the past two years?  What add-ons were not sponsored?  Any way to limit the list or simplify the list?  
+  - Maybe give add-on numbers per tier of sponsorship?
+    - What virtual add-ons that were sponsored in the past two years?
+    - What add-ons were not sponsored?
+    - Any way to limit the list or simplify the list?
   - Don't restrict things
   - Range of money for tiers?
   - Limit choices
   - How to bring in enough money for next year without scaring away companies.
 - Sill unsure how to handle small/local sponsors.
-- Can we note local businesses no matter the size of the company?  
+- Can we note local businesses no matter the size of the company?
   - Can we have special ribbons for speakers, sponsors, local, etc?
-[ ] Take a look at organizing add-ons (Hans)
+- [ ] Take a look at organizing add-ons (Hans)
 
 #### Sponsorship Spreadsheet
-[ ] investigate formular to capture person and datestamp when an account is marked paid (hans)
+- [ ] investigate formular to capture person and datestamp when an account is marked paid (hans)
 - Hans worked on formulas, but did not get that far.
   - 3-5 hours to convert it.
   - how do we want to deal with sponsors
-    - paid vs non-paid.   OSI not involved with non-paid, but contracts, etc?
+    - paid vs non-paid.
+      - OSI not involved with non-paid, but contracts, etc?
     - keep lead sheet seperate from the actual sponsor spreadsheet.
       - reduce info/discussion with OSI
       - protect info of lead sheet.
   - people/timestamps is difficult.   may just use dropdowns/hand enter
   - Hans looking at NextCloud.
-  [x] determine loe to move to OSI budget spreadsheet (hans)
-  [ ] Finish prepping the OSI spreadsheet (hans and norm working session)
-  [ ]  Move Lead Sheet over to NextCloud  (hans and norm working session)
+  - [x] determine loe to move to OSI budget spreadsheet (hans)
+  - [ ] Finish prepping the OSI spreadsheet (hans and norm working session)
+  - [ ] Move Lead Sheet over to NextCloud  (hans and norm working session)
 
 ###  Sponsors
-- Different tier for smaller companies/individual?   
+- Different tier for smaller companies/individual?
 
 ### higher priority spreadsheet or prospectus?
 - prospectus would seem a higher priority, but...
-  - We do not know what we are doing this year.   hybrid or virtual
+  - We do not know what we are doing this year.
+    - hybrid or virtual
   - prospectus delayed until venue type is decided next month.
 - Spreadsheet higher priority right now.
   - fields to document OSI 'API'.
   - also track who enters what on which date.
   - easy to use/transform data from monthly updates.
-
-
 
 ### Outstanding Financial items
 - Email from Ben
@@ -98,44 +101,46 @@
 - Monthly meetins with OSI financial?
   - Maybe get the monthly data a week before? Not waiting for the day of to review.
   - New, outstanding, recent items.
-  [ ] Include in email to OSI (Norm)
-- Salt paying for storage.  Moved out and then in.
-  
+  - [ ] Include in email to OSI (Norm)
+- Salt paying for storage.
+  - Moved out and then in.
+
 ### Misc Items
-  - Periodic coffee/doughnuts for the teams?
-    - Maybe OSI when we first meeting with them.
-    - Committees...  $200 for each for team building?
-       - Feedback in the All-hands
-    - Gift Cards for remote/virtual meetings?
+- Periodic coffee/doughnuts for the teams?
+- Maybe OSI when we first meeting with them.
+- Committees...  $200 for each for team building?
+  - Feedback in the All-hands
+- Gift Cards for remote/virtual meetings?
 
 ## Retrospective
-  - https://github.com/SeaGL/organization/blob/main/meetings/2021/20211115-retrospective.md
-  - work through budget requests, including old ones stuck around from 2020 (Hans)
-  - add links referencing documents that committee generated (or relied on) for 2021 (Everyone)
-    - https://etherpad.seattlematrix.org/p/SeaGL_2021_links
-  - submit 2021 reimbursement requests before Dec 1 by opening a GH issue and tagging der.hans (Everyone)
-  - confirm Mind's Eye has gotten paid from OSI (Salt)
-    - Meet with OSI
-      - What can we legally do to give them up to 5K?
-      - What other 'gotchas' for using out of country peole?
-      - A way to change the contract/wording to not have the 30% held?
-      - Need to test spreadsheet/process
-    - Can we make it right by giving a 'bonus'?
-    - Talk to Nathan (after OSI meeting).
-  - Bikeshed
-    - continue to streamline sponsor processing
-    - fully transition to consistent document formats
-    - write more documentation for external consumption
+- https://github.com/SeaGL/organization/blob/main/meetings/2021/20211115-retrospective.md
+- work through budget requests, including old ones stuck around from 2020 (Hans)
+- add links referencing documents that committee generated (or relied on) for 2021 (Everyone)
+  - https://etherpad.seattlematrix.org/p/SeaGL_2021_links
+- submit 2021 reimbursement requests before Dec 1 by opening a GH issue and tagging der.hans (Everyone)
+- [ ] confirm Mind's Eye has gotten paid from OSI (Salt)
+  - Meet with OSI
+    - What can we legally do to give them up to 5K?
+    - What other 'gotchas' for using out of country peole?
+    - A way to change the contract/wording to not have the 30% held?
+    - Need to test spreadsheet/process
+  - Can we make it right by giving a 'bonus'?
+  - Talk to Nathan (after OSI meeting).
 
-  ## Timeline
-  - Decision on hybrid/virtual first meeting after May 1.
-    - Prospectus middle of May
-  - Monthly transactions - April 25th.
-  - Outstanding financial items
-    - Ben's April 18th.
-    - Find all items already turned in...  get summary.
-      [ ] Norm to gather list - 5/23
-      - See what is not in process yet.
+### Bikeshed
+- continue to streamline sponsor processing
+- fully transition to consistent document formats
+- write more documentation for external consumption
+
+## Timeline
+- Decision on hybrid/virtual first meeting after May 1.
+  - Prospectus middle of May
+- Monthly transactions - April 25th.
+- Outstanding financial items
+  - Ben's April 18th.
+  - Find all items already turned in...  get summary.
+    - [ ] Norm to gather list - 5/23
+    - See what is not in process yet.
 
 ###  Transaction Tech
 - Ask tech if can have a github template for budget items, re-imbursements,
@@ -147,7 +152,7 @@
   - Need to discuss on next meeting.
 
 # IDEA - mentioned in meeting.
-[x] Hans requesting writeup of what we are looking for in people (Salt).
+- [x] Hans requesting writeup of what we are looking for in people (Salt).
 - Everyone to look at, perferably someone in addition to finance.
 - https://pad.seattlematrix.org/p/SeaGL_2022_IDEA-first_message
 

--- a/meetings/2022/20220620-finance_and_partnerships.md
+++ b/meetings/2022/20220620-finance_and_partnerships.md
@@ -1,7 +1,6 @@
-
 # 2022.06.20 SeaGl Finance
-
 - June 20th, 2022. 1600 Pacific Time
+
 - [Shared Pad](https://pad.seattlematrix.org/p/SeaGL_2022_finance)
 - [Jitsi URL](https://meet.seattlematrix.org/SeaGL_2022_finance)
 - [Previous meeting minutes](https://github.com/SeaGL/organization/tree/main/meetings/2022)
@@ -16,7 +15,7 @@
 - Facilitator: Norm
 - Note Taker(s): Norm
 - Note Taker(s) for next time: 
-    
+
 - Norm: still phreaking about house, joys of modifying house
 - Sri: been a whole year of changes, busy with job search, doing some Open Source stuff at Intel
 - Salt: also freaking out about unemployment, but spent a week out camping
@@ -27,7 +26,6 @@
 # Agenda
 ## Previous ToDo
 ### Angenda for next meeting
-  
 
 ### References
 - [2021 fiscal sponsor details](https://docs.google.com/spreadsheets/d/1On-iXCVhR1jgV4hCXdmTkLunlayPYrMA9nCmRBwuz10/)
@@ -46,11 +44,12 @@
 - CC finance on all emails with OSI.
   - [ ] Email OSI and start discussion on the above  (Norm) - Do by 6/7
   - https://pad.seattlematrix.org/p/SeaGL_2022_finance_OSI_initial_email
+
 ### sponsor prospectus timeline / shared labor
 - [ ] request monthly transactions (hans/norm)  - Add to OSI email
 
 #### Prospectus/Sponsorship discussion
-- Can we note local businesses no matter the size of the company?  
+- Can we note local businesses no matter the size of the company?
   - Can we have special ribbons for speakers, sponsors, local, etc? (question for tech team?)
   - Multiple years, both sponsors and speakers.  Maybe do something once we get back?
     - scavenger hunt?
@@ -65,11 +64,13 @@
 - Hans worked on formulas, but did not get that far.
   - 3-5 hours to convert it.
   - how do we want to deal with sponsors
-    - paid vs non-paid.   OSI not involved with non-paid, but contracts, etc?
+    - paid vs non-paid.
+      - OSI not involved with non-paid, but contracts, etc?
     - keep lead sheet seperate from the actual sponsor spreadsheet.
       - reduce info/discussion with OSI
       - protect info of lead sheet.
-  - people/timestamps is difficult.   may just use dropdowns/hand enter
+  - people/timestamps is difficult.
+    - may just use dropdowns/hand enter
   - Hans looking at NextCloud.
   - [ ] Finish prepping the OSI budget spreadsheet (hans and norm working session)
   - [ ] Move Lead Sheet over to NextCloud  (hans and norm working session)
@@ -99,15 +100,16 @@
   - Maybe get the monthly data a week before? Not waiting for the day of to review.
   - New, outstanding, recent items.
   - [ ] Include in email to OSI (Norm)
-- Salt paying for storage.  Moved out and then in.
+- Salt paying for storage.
+  - Moved out and then in.
 
 ### Misc Items
 - Periodic coffee/doughnuts for the teams?
   - Maybe OSI when we first meeting with them.
-  - Committees...  $200 for each for team building?
-     - Feedback in the All-hands
-     - Ask OSI if this is an issue.  OSI email+
-  - Gift Cards for remote/virtual meetings?
+- Committees...  $200 for each for team building?
+   - Feedback in the All-hands
+   - Ask OSI if this is an issue.  OSI email+
+- Gift Cards for remote/virtual meetings?
 
 ## Retrospective
 - confirm Mind's Eye has gotten paid from OSI (Salt)
@@ -118,18 +120,19 @@
     - Need to test spreadsheet/process
   - Can we make it right by giving a 'bonus'?
   - Talk to Nathan (after OSI meeting).
-- Bikeshed
-  - fully transition to consistent document formats
-  - write more documentation for external consumption
+
+### Bikeshed
+- fully transition to consistent document formats
+- write more documentation for external consumption
 
 ## Timeline
 - Monthly transactions - Jul 18
 - Meet with tech team about reimbursement templates (Hans) - Jun 13
-~~- Outstanding financial items~~
- ~~ - Ben's April 18th email.~~
-  ~~- Find all items already turned in...  get summary.~~
-    ~~[ ] Norm to gather list - 6/20~~
-    ~~- See what is not in process yet.~~
+- ~~Outstanding financial items~~
+  - ~~Ben's April 18th email.~~
+  - ~~Find all items already turned in...  get summary.~~
+    - [ ] ~~Norm to gather list - 6/20~~
+    - ~~See what is not in process yet.~~
 
 ###  Transaction Tech
 - Ask tech if can have a github template for budget items, re-imbursements,


### PR DESCRIPTION
Various tweaks to finance/partnership meeting note markdown. Not entirely consistent but weighed the value of having cleaner formatting with going back and making sure content from one meeting was only included in that meeting.